### PR TITLE
Remove Info button from header to give a more uniform appearance

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -15,14 +15,7 @@ function Header() {
 
         <img src={background} className="background-image" alt="" />
 
-
-
-        <div className="counter-flex">
-          <Countdown />
-          <a className="rsvp" href="#information">
-            <h6>Info ↓</h6>
-          </a>
-        </div>
+        <Countdown />
 
 
       </div>

--- a/src/components/Information.js
+++ b/src/components/Information.js
@@ -15,7 +15,7 @@ function Information() {
       {// <p>S'mores may be included.</p>
     }</article>
 
-    <div class="parralax par_one"></div>
+    <div className="parralax par_one"></div>
 
     <article>
       <h1>Location</h1>
@@ -30,7 +30,7 @@ function Information() {
       <p>Other Accomodations 15-20 min drive away</p>
     </article>
 
-    <div class="parralax par_two"></div>
+    <div className="parralax par_two"></div>
 
     <article>
       <h1>Catering, RSVP, Registry & more</h1>
@@ -39,7 +39,7 @@ function Information() {
       <p>RSVP, Meal Selection and Registry incoming...</p>
     </article>
 
-    <div class="parralax par_three"></div>
+    <div className="parralax par_three"></div>
 
 
   </div>

--- a/src/components/css/Header.css
+++ b/src/components/css/Header.css
@@ -4,7 +4,6 @@ h1 {
 
 .Header-Component {
   min-width:100vw;
-  min-height: 100vh;
 }
 @media only screen and (min-width: 1000px) {
   .Header-Component {
@@ -13,7 +12,6 @@ h1 {
 }
 
 .header {
-  min-height: 100vh;
   min-width: 100vw;
 }
 
@@ -48,7 +46,7 @@ h1 {
 
 .clock-card {
   display: inline-block;
-  padding: 2rem 3rem 5rem 3rem;
+  padding: 5rem 3rem;
   background: var(--ch-maroon);
 }
 @media only screen and (min-width: 1000px) {
@@ -132,30 +130,4 @@ h1 {
   margin: 0;
   text-shadow: inherit;
   user-select: none;
-}
-.counter-flex{
-  width: 30vw;
-  background: var(--ch-maroon);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 7vh 1rem;
-}
-@media only screen and (min-width: 1000px) and (max-width: 1405px) {
-  .counter-flex {
-    width: 35vw;
-  }
-}
-@media only screen and (max-width: 1197px) {
-  .counter-flex { /*This is to stop the countdown text from wrapping off of its lines*/
-    flex-direction: column;
-  }
-}
-@media only screen and (max-width: 1000px) {
-  .counter-flex {
-    width: 75vw;
-    margin: 0 auto;
-    padding:0;
-    flex-direction: row;
-  }
 }


### PR DESCRIPTION
In addition I also removed the max-height rule from the header component to allow for a seamless transition to the multitabpane no matter how wide the viewing screen is.

As it stood, I was trying to use padding to always make the countdown timer touch the multitab pane as the header could be too tall for it. Now that is not an issue.